### PR TITLE
Makefile tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ clean:
 	rm -f bzip3 libbzip3.so obj/*.o
 
 format:
+	@which clang-format > /dev/null || ( sh -c "printf 'clang-format not found! See https://clang.llvm.org/docs/ClangFormat.html\n'"; false; )
 	clang-format -i src/*.c include/*.h
 
 install: all
@@ -32,6 +33,7 @@ install: all
 	install -c -v -m 755 include/libbz3.h $(PREFIX)/include
 
 cloc:
+	@which cloc > /dev/null || ( sh -c "printf 'cloc not found! download it from github.com/AlDanial/cloc\n'"; false; )
 	cloc src/*.c include/*.h
 
 check: bzip3

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ clean:
 format:
 	clang-format -i src/*.c include/*.h
 
-install:
+install: all
 	install -c -v -m 755 bzip3 $(PREFIX)/bin
 	install -c -v -m 755 libbzip3.so $(PREFIX)/lib
 	install -c -v -m 755 include/libbz3.h $(PREFIX)/include


### PR DESCRIPTION
Two minor changes:
1. Make the `install` target in the Makefile depend upon the `all` target. This way, you can type `make install` and it will compile and install in one step.
2. I added some awesomeness to the `format` and `cloc` target, so if someone tries to build those targets, they will see a useful URL to download the binary tool, if they don't already have it installed. 