### PR TITLE
Fix inverted CFLAGS detection, move earier in build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,12 +5,12 @@ AM_INIT_AUTOMAKE([foreign subdir-objects tar-pax color-tests])
 AM_SILENT_RULES([yes])
 AC_CONFIG_MACRO_DIR([build-aux])
 
+AC_MSG_CHECKING([whether system or user specificed compiler flags are set])
+AM_CONDITIONAL([PASSED_CFLAGS], [test -n "$CFLAGS"])
+AM_COND_IF([PASSED_CFLAGS], [AC_MSG_RESULT([yes])], [AC_MSG_RESULT([no])])
+
 AC_PROG_CC([clang gcc icc])
 LT_INIT
-
-AC_MSG_CHECKING([whether system or user specificed compiler flags are set])
-AM_CONDITIONAL([PASSED_CFLAGS], [test -z "$CFLAGS"])
-AM_COND_IF([PASSED_CFLAGS], [AC_MSG_RESULT([yes])], [AC_MSG_RESULT([no])])
 
 AC_ARG_WITH([pthread],
 			  AS_HELP_STRING([--without-pthread], [Disable use of pthread library]))


### PR DESCRIPTION
The final commit 42a066c added into #12 inverts the correct logic to be backwards. The real problem is that the detection of existing flags was being done after checking for CC and setting up library build options—which was setting some CFLAGS. This corrects the logic back to `test -n "$CFLAGS"` but moves the check earlier in the configure process so it happens before autotools starts setting any system specific CFLAGS on us.
