### PR TITLE
Add release automation stuff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,26 @@ jobs:
       - name: Build source packages
         run: |
           make dist
+          bzip2 -d -k bzip3-${{ github.ref_name }}.tar.bz2
+          zstd -19 bzip3-${{ github.ref_name }}.tar
+          7z a bzip3-${{ github.ref_name}}.tar{.7z,}
+      - name: Build a binary (for dogfooding)
+        run: make
+      - name: Create a dogfood package
+        run: |
+          ./bzip3 -e bzip3-${{ github.ref_name }}.tar
       - name: Publish Release
         uses: softprops/action-gh-release@v1
         with:
           files: |
+            bzip3-${{ github.ref_name }}.tar
+            bzip3-${{ github.ref_name }}.tar.7z
+            bzip3-${{ github.ref_name }}.tar.bz2
+            bzip3-${{ github.ref_name }}.tar.bz3
             bzip3-${{ github.ref_name }}.tar.gz
+            bzip3-${{ github.ref_name }}.tar.xz
+            bzip3-${{ github.ref_name }}.tar.zst
+            bzip3-${{ github.ref_name }}.zip
       - name: Upload source package artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,3 +25,43 @@ jobs:
         with:
           files: |
             bzip3-${{ github.ref_name }}.tar.gz
+      - name: Upload source package artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: bzip3-${{ github.ref_name }}
+          path: bzip3-${{ github.ref_name }}.tar.gz
+
+  binaries:
+    name: Publish Binaries on GitHub Release
+    needs: [ ghrelease ]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - [ "x86_64-linux", "", "" ]
+          - [ "x86_64", "CC=x86_64-w64-mingw32-gcc --host x86_64-w64-mingw32", "gcc-mingw-w64-x86-64" ]
+          - [ "i686", "CC=i686-w64-mingw32-gcc --host i686-w64-mingw32", "gcc-mingw-w64-i686" ]
+    steps:
+      - name: Download source package artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: bzip3-${{ github.ref_name }}
+      - name: Extract source package
+        run: tar --strip-components=1 -xf bzip3-${{ github.ref_name }}.tar.gz
+      - name: Install cross-compile dependencies
+        if: ${{ matrix.target[2] }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ matrix.target[2] }}
+      - name: Configure
+        run: ./configure --bindir=/ --program-suffix=-${{ matrix.target[0] }} ${{ matrix.target[1] }}
+      - name: Make
+        run: |
+          make
+          make DESTDIR=$(pwd)/output install-exec
+      - name: Publish binary
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            output/bzip3-${{ matrix.target[0] }}*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+jobs:
+
+  ghrelease:
+    name: Publish sources on GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Configure
+        run: |
+          ./bootstrap.sh
+          ./configure
+      - name: Build source packages
+        run: |
+          make dist
+      - name: Publish Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            bzip3-${{ github.ref_name }}.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ tags
 *.so
 bzip3
 bzip3-*
+.version
 
 # Autotools
 .deps/
@@ -28,6 +29,7 @@ bzip3-*
 Makefile
 Makefile.in
 autom4te.cache/
-build-aux/
-!build-aux/ax_pthread.m4
-!build-aux/ax_check_compile_flag.m4
+/build-aux/*
+!/build-aux/ax_check_compile_flag.m4
+!/build-aux/ax_pthread.m4
+!/build-aux/git-version-gen

--- a/Makefile.am
+++ b/Makefile.am
@@ -26,6 +26,8 @@ bzip3_CFLAGS = $(AM_CFLAGS)
 bzip3_LDDADD = libbzip3.la
 bzip3_SOURCES = src/main.c $(libbzip3_la_SOURCES)
 
+CLEANFILES = $(bin_PROGRAMS)
+
 # End standard autotools stuff, begin developer convenience targets
 
 .PHONY: format

--- a/Makefile.am
+++ b/Makefile.am
@@ -3,7 +3,7 @@ ACLOCAL_AMFLAGS = -I build-aux
 AM_CFLAGS = -I$(top_srcdir)/include
 AM_LDFLAGS = -avoid-version
 
-EXTRA_DIST = LICENSE PORTING.md README.md
+EXTRA_DIST = LICENSE PORTING.md README.md build-aux/git-version-gen
 
 include_HEADERS = include/libbz3.h
 noinst_HEADERS = include/cm.h \
@@ -26,7 +26,26 @@ bzip3_CFLAGS = $(AM_CFLAGS)
 bzip3_LDDADD = libbzip3.la
 bzip3_SOURCES = src/main.c $(libbzip3_la_SOURCES)
 
-CLEANFILES = $(bin_PROGRAMS)
+BUILT_SOURCES = .version
+CLEANFILES = $(BUILT_SOURCES) .version-prev $(bin_PROGRAMS)
+
+_BRANCH_REF != $(AWK) '{print ".git/" $$2}' .git/HEAD 2>/dev/null
+
+.version: $(_BRANCH_REF)
+	if [ -e "$@" ]; then \
+		mv "$@" "$@-prev"; \
+	else \
+		[ -e "$<" ] && touch "$@-prev" || cp "$(srcdir)/.tarball-version" "$@-prev"; \
+	fi
+	if [ -e "$<" ]; then \
+		./build-aux/git-version-gen "$(srcdir)/.tarball-version"; \
+		cmp -s "$@" "$@-prev" || autoreconf configure.ac --force; \
+	else \
+		printf "$(VERSION)"; \
+	fi > $@
+
+dist-hook:
+	printf "$(VERSION)" > "$(distdir)/.tarball-version"
 
 # End standard autotools stuff, begin developer convenience targets
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,24 @@
 #!/usr/bin/env sh
 set -e
 
+incomplete_source () {
+    printf '%s\n' \
+        "$1. Please either:" \
+        "* $2," \
+        "* or use the source packages instead of a repo archive" \
+        "* or use a full Git clone." >&2
+    exit 1
+}
+
+# This enables easy building from Github's snapshot archives
+if [ ! -e ".git" ]; then
+    if [ ! -f ".tarball-version" ]; then
+    incomplete_source "No version information found" \
+        "identify the correct version with \`echo \$version > .tarball-version\`"
+    fi
+else
+    # Just a head start to save a ./configure cycle
+    ./build-aux/git-version-gen .tarball-version > .version
+fi
+
 autoreconf --install

--- a/build-aux/git-version-gen
+++ b/build-aux/git-version-gen
@@ -1,0 +1,220 @@
+#!/usr/bin/env sh
+
+# Print a version string.
+scriptversion=2012-03-18.17; # UTC
+
+# Copyright (C) 2007-2012 Free Software Foundation, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# This script is derived from GIT-VERSION-GEN from GIT: http://git.or.cz/.
+# It may be run two ways:
+# - from a git repository in which the "git describe" command below
+#   produces useful output (thus requiring at least one signed tag)
+# - from a non-git-repo directory containing a .tarball-version file, which
+#   presumes this script is invoked like "./git-version-gen .tarball-version".
+
+# In order to use intra-version strings in your project, you will need two
+# separate generated version string files:
+#
+# .tarball-version - present only in a distribution tarball, and not in
+#   a checked-out repository.  Created with contents that were learned at
+#   the last time autoconf was run, and used by git-version-gen.  Must not
+#   be present in either $(srcdir) or $(builddir) for git-version-gen to
+#   give accurate answers during normal development with a checked out tree,
+#   but must be present in a tarball when there is no version control system.
+#   Therefore, it cannot be used in any dependencies.  GNUmakefile has
+#   hooks to force a reconfigure at distribution time to get the value
+#   correct, without penalizing normal development with extra reconfigures.
+#
+# .version - present in a checked-out repository and in a distribution
+#   tarball.  Usable in dependencies, particularly for files that don't
+#   want to depend on config.h but do want to track version changes.
+#   Delete this file prior to any autoconf run where you want to rebuild
+#   files to pick up a version string change; and leave it stale to
+#   minimize rebuild time after unrelated changes to configure sources.
+#
+# As with any generated file in a VC'd directory, you should add
+# /.version to .gitignore, so that you don't accidentally commit it.
+# .tarball-version is never generated in a VC'd directory, so needn't
+# be listed there.
+#
+# Use the following line in your configure.ac, so that $(VERSION) will
+# automatically be up-to-date each time configure is run (and note that
+# since configure.ac no longer includes a version string, Makefile rules
+# should not depend on configure.ac for version updates).
+#
+# AC_INIT([GNU project],
+#         m4_esyscmd([build-aux/git-version-gen .tarball-version]),
+#         [bug-project@example])
+#
+# Then use the following lines in your Makefile.am, so that .version
+# will be present for dependencies, and so that .version and
+# .tarball-version will exist in distribution tarballs.
+#
+# EXTRA_DIST = $(top_srcdir)/.version
+# BUILT_SOURCES = $(top_srcdir)/.version
+# $(top_srcdir)/.version:
+#	echo $(VERSION) > $@-t && mv $@-t $@
+# dist-hook:
+#	echo $(VERSION) > $(distdir)/.tarball-version
+
+
+me=$0
+
+version="git-version-gen $scriptversion
+
+Copyright 2011 Free Software Foundation, Inc.
+There is NO warranty.  You may redistribute this software
+under the terms of the GNU General Public License.
+For more information about these matters, see the files named COPYING."
+
+usage="\
+Usage: $me [OPTION]... \$srcdir/.tarball-version [TAG-NORMALIZATION-SED-SCRIPT]
+Print a version string.
+
+Options:
+
+   --prefix           prefix of git tags
+
+   --help             display this help and exit
+   --version          output version information and exit
+
+Running without arguments will suffice in most cases."
+
+prefix=
+
+while test $# -gt 0; do
+  case $1 in
+    --help) echo "$usage"; exit 0;;
+    --version) echo "$version"; exit 0;;
+    --prefix) shift; prefix="$1";;
+    -*)
+      echo "$0: Unknown option '$1'." >&2
+      echo "$0: Try '--help' for more information." >&2
+      exit 1;;
+    *)
+      if test -z "$tarball_version_file"; then
+        tarball_version_file="$1"
+      elif test -z "$tag_sed_script"; then
+        tag_sed_script="$1"
+      else
+        echo "$0: extra non-option argument '$1'." >&2
+        exit 1
+      fi;;
+  esac
+  shift
+done
+
+if test -z "$tarball_version_file"; then
+    echo "$usage"
+    exit 1
+fi
+
+tag_sed_script="${tag_sed_script:-s/x/x/}"
+
+nl='
+'
+
+# Avoid meddling by environment variable of the same name.
+v=
+v_from_git=
+
+# First see if there is a tarball-only version file.
+# then try "git describe", then default.
+if test -f $tarball_version_file
+then
+    v=`cat $tarball_version_file` || v=
+    case $v in
+        *$nl*) v= ;; # reject multi-line output
+        [0-9]*) ;;
+        *) v= ;;
+    esac
+    test -z "$v" \
+        && echo "$0: WARNING: $tarball_version_file is missing or damaged" 1>&2
+fi
+
+if test -n "$v"
+then
+    : # use $v
+# Otherwise, if there is at least one git commit involving the working
+# directory, and "git describe" output looks sensible, use that to
+# derive a version string.
+elif test "`git log -1 --pretty=format:x . 2>/dev/null`" = x \
+    && v=`git describe --tags --abbrev=7 --match="$prefix*" HEAD 2>/dev/null \
+          || git describe --tags --abbrev=7 HEAD 2>/dev/null \
+          || git log -1 --pretty=format:'v0-HEAD-%h' 2>/dev/null` \
+    && v=`printf '%s\n' "$v" | sed "$tag_sed_script"` \
+    && case $v in
+         $prefix[0-9]*) ;;
+         *) (exit 1) ;;
+       esac
+then
+    # Is this a new git that lists number of commits since the last
+    # tag or the previous older version that did not?
+    #   Newer: v6.10-77-g0f8faeb
+    #   Older: v6.10-g0f8faeb
+    case $v in
+        *-*-*) : git describe is okay three part flavor ;;
+        *-*)
+            : git describe is older two part flavor
+            # Recreate the number of commits and rewrite such that the
+            # result is the same as if we were using the newer version
+            # of git describe.
+            vtag=`echo "$v" | sed 's/-.*//'`
+            commit_list=`git rev-list "$vtag"..HEAD 2>/dev/null` \
+                || { commit_list=failed;
+                     echo "$0: WARNING: git rev-list failed" 1>&2; }
+            numcommits=`echo "$commit_list" | wc -l`
+            v=`echo "$v" | sed "s/\(.*\)-\(.*\)/\1-$numcommits-\2/"`;
+            test "$commit_list" = failed && v=UNKNOWN
+            ;;
+    esac
+
+    v=`echo "$v" | sed 's/-/.r/'`;
+    v_from_git=1
+else
+    v=UNKNOWN
+fi
+
+v=`echo "$v" |sed "s/^$prefix//"`
+
+# Test whether to append the "-dirty" suffix only if the version
+# string we're using came from git.  I.e., skip the test if it's "UNKNOWN"
+# or if it came from .tarball-version.
+if test -n "$v_from_git"; then
+  # Don't declare a version "dirty" merely because a time stamp has changed.
+  git update-index --refresh > /dev/null 2>&1
+
+  dirty=`exec 2>/dev/null;git diff-index --name-only HEAD` || dirty=
+  case "$dirty" in
+      '') ;;
+      *) # Append the suffix only if there isn't one already.
+          case $v in
+            *-dirty) ;;
+            *) v="$v-dirty" ;;
+          esac ;;
+  esac
+fi
+
+# Omit the trailing newline, so that m4_esyscmd can use the result directly.
+echo "$v" | tr -d "$nl"
+
+# Local variables:
+# eval: (add-hook 'write-file-hooks 'time-stamp)
+# time-stamp-start: "scriptversion="
+# time-stamp-format: "%:y-%02m-%02d.%02H"
+# time-stamp-time-zone: "UTC"
+# time-stamp-end: "; # UTC"
+# End:

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_PREREQ([2.68])
 AC_INIT([bzip3], [m4_esyscmd(build-aux/git-version-gen .tarball-version)], [https://github.com/kspalaiologos/bzip3])
 AC_CONFIG_AUX_DIR([build-aux])
-AM_INIT_AUTOMAKE([foreign subdir-objects tar-pax color-tests])
+AM_INIT_AUTOMAKE([foreign subdir-objects tar-ustar dist-bzip2 dist-xz dist-zip color-tests])
 AM_SILENT_RULES([yes])
 AC_CONFIG_MACRO_DIR([build-aux])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.68])
-AC_INIT([bzip3], [1.1.1], [https://github.com/kspalaiologos/bzip3])
+AC_INIT([bzip3], [m4_esyscmd(build-aux/git-version-gen .tarball-version)], [https://github.com/kspalaiologos/bzip3])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([foreign subdir-objects tar-pax color-tests])
 AM_SILENT_RULES([yes])
@@ -10,6 +10,7 @@ AM_CONDITIONAL([PASSED_CFLAGS], [test -n "$CFLAGS"])
 AM_COND_IF([PASSED_CFLAGS], [AC_MSG_RESULT([yes])], [AC_MSG_RESULT([no])])
 
 AC_PROG_CC([clang gcc icc])
+AC_PROG_AWK
 LT_INIT
 
 AC_ARG_WITH([pthread],


### PR DESCRIPTION
See #13 and #15

This automates two different parts of the release process:

1. Instead of hard coding a version in `configure.ac`, it derives the current version from either Git meta data (for clones) or from an included meta data file (for source packages). This means that the release process can now git `git tag X.Y.Z && git push --tags` (or of course adding a tag from the GitHub interface). Notably no changes need to be made *in* the source to get properly versioned releases.

   This does have one drawback: building from Git clones is fine and building from source packages is fine, but building from `git archive` generated snapshot tar files is a wee bit harder. A hint is available in the `bootstrap.sh` file for how to make it work for anybody that hits that problem.

2. This builds the source dist and attaches it to GitHub releases for any new tags posted.

   As long as I was at it, I figured since this is a compression format project it might be good advertising if we dogfood it, so I added a bunch of other compression formats as well as a bz3 version.

   Additionally I added cross compiling for Linux and Windows static binaries and attached them too.

   This is hard to test on the real project, but you can see what it looks like in [my fork's CI runs](https://github.com/alerque/bzip3/actions/runs/2316319235) and a resulting [sample release here](https://github.com/alerque/bzip3/releases/tag/1.1.2).

    ![image](https://user-images.githubusercontent.com/173595/168177591-8e3e9437-2ba8-47e0-9a05-3bdcb814c684.png)
