### PR TITLE
Fix version handling causing duplicate configure runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ etc/bitflip
 
 # Editor stuff
 .vscode/
-*.~
+*~
 tags
 
 # Generated
@@ -16,6 +16,7 @@ tags
 bzip3
 bzip3-*
 .version
+.version-prev
 
 # Autotools
 .deps/
@@ -33,7 +34,3 @@ autom4te.cache/
 !/build-aux/ax_check_compile_flag.m4
 !/build-aux/ax_pthread.m4
 !/build-aux/git-version-gen
-
-.version-prev
-
-configure~

--- a/Makefile.am
+++ b/Makefile.am
@@ -33,24 +33,23 @@ CLEANFILES = $(bin_PROGRAMS)
 # Begin special handling for autoconf VERSION being updated on commit
 
 BUILT_SOURCES = .version
-CLEANFILES += $(BUILT_SOURCES) .version-prev .version-next
+CLEANFILES += $(BUILT_SOURCES) .version-prev
 
 src/bzip3-main.$(OBJEXT): .version
 
 _BRANCH_REF != $(AWK) '{print ".git/" $$2}' .git/HEAD 2>/dev/null
 
 .version: $(_BRANCH_REF)
-	if [ -e "$@" ]; then \
-		mv "$@" "$@-prev"; \
+	@if [ -e "$(srcdir)/.tarball-version" ]; then \
+		printf "$(VERSION)" > $@; \
 	else \
-		[ -e "$<" ] && touch "$@-prev" || cp "$(srcdir)/.tarball-version" "$@-prev"; \
-	fi
-	if [ -e "$<" ]; then \
-		./build-aux/git-version-gen "$(srcdir)/.tarball-version"; \
+		touch "$@-prev"; \
+		if [ -e "$@" ]; then \
+			cp "$@" "$@-prev"; \
+		fi; \
+		./build-aux/git-version-gen "$(srcdir)/.tarball-version" > $@; \
 		cmp -s "$@" "$@-prev" || autoreconf configure.ac --force; \
-	else \
-		printf "$(VERSION)"; \
-	fi > $@
+	fi
 
 dist-hook:
 	printf "$(VERSION)" > "$(distdir)/.tarball-version"


### PR DESCRIPTION
This is to fix a logic bug in my own submissions. Handling setting the VERSION value in autoconf based on Git forces a reconfigure every time the current HEAD changes (by necessity). Tracking this but *also* allowing static source tarballs work nicely without any Git metadata involves an output file with a hard coded version generated at source package time. The project I copied this code from (one of my own, git-warp-time) did not have a BSD compatible target for this, so I rewrote it to work with `bmake` when submitting to this project. In doing that rewrite I overlooked and order of operations thing that is not causing the builds from source tarballs to trigger configure runs *twice*. It still works but wastes some cycles and makes autoconf look even more pedantically slow than it legitimately is. This should fix that.