### PR TITLE
Generate and install pkg-config info so other projects can find headers easily

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,6 +5,8 @@ AM_LDFLAGS = -avoid-version
 
 EXTRA_DIST = LICENSE PORTING.md README.md build-aux/git-version-gen
 
+pkgconfig_DATA = bzip3.pc
+
 include_HEADERS = include/libbz3.h
 noinst_HEADERS = include/cm.h \
 						 include/common.h \

--- a/bzip3.pc.in
+++ b/bzip3.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+bindir=@bindir@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: @PACKAGE@
+Description: A better and stronger spiritual successor to BZip2
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lbz3
+Cflags: -I${includedir}

--- a/configure.ac
+++ b/configure.ac
@@ -13,6 +13,9 @@ AC_PROG_CC([clang gcc icc])
 AC_PROG_AWK
 LT_INIT
 
+PKG_PROG_PKG_CONFIG
+PKG_INSTALLDIR
+
 AC_ARG_WITH([pthread],
 			  AS_HELP_STRING([--without-pthread], [Disable use of pthread library]))
 AM_CONDITIONAL([WITH_PTHREAD], [test x"$with_pthread" != xno])
@@ -52,5 +55,6 @@ AM_COND_IF([PASSED_CFLAGS], [
 ])
 
 AC_CONFIG_FILES([Makefile])
+AC_CONFIG_FILES([bzip3.pc])
 AC_ARG_PROGRAM
 AC_OUTPUT


### PR DESCRIPTION
As mentioned in [comments here](https://github.com/kspalaiologos/bzip3/pull/12#issuecomment-1124826612).

**CAVEAT**: I haven't used this in anything myself! I am pretty confident in the autotools part of generating this template and installing in, but I'm not at all confident about the `Libs:` line in particular being correct for this project:

```
Libs: -L${libdir} -lbz3
```

It would be nice if somebody could confirm the result here is actually usable.