### PR TITLE
Add help and version flags, show version info in help

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,8 +26,16 @@ bzip3_CFLAGS = $(AM_CFLAGS)
 bzip3_LDDADD = libbzip3.la
 bzip3_SOURCES = src/main.c $(libbzip3_la_SOURCES)
 
+CLEANFILES = $(bin_PROGRAMS)
+
+# End standard generic autotools stuff
+
+# Begin special handling for autoconf VERSION being updated on commit
+
 BUILT_SOURCES = .version
-CLEANFILES = $(BUILT_SOURCES) .version-prev $(bin_PROGRAMS)
+CLEANFILES += $(BUILT_SOURCES) .version-prev .version-next
+
+src/bzip3-main.$(OBJEXT): .version
 
 _BRANCH_REF != $(AWK) '{print ".git/" $$2}' .git/HEAD 2>/dev/null
 
@@ -47,7 +55,7 @@ _BRANCH_REF != $(AWK) '{print ".git/" $$2}' .git/HEAD 2>/dev/null
 dist-hook:
 	printf "$(VERSION)" > "$(distdir)/.tarball-version"
 
-# End standard autotools stuff, begin developer convenience targets
+# Begin developer convenience targets
 
 .PHONY: format
 format: $(bzip3_SOURCES) $(include_HEADERS) $(noinst_HEADERS)

--- a/src/main.c
+++ b/src/main.c
@@ -101,6 +101,9 @@ int main(int argc, char * argv[]) {
             } else if (argv[i][1] == 'h') {
                 mode = 0;
                 args_status = 0;
+            } else if (argv[i][1] == 'v') {
+                fprintf(stderr, "bzip3 %s", VERSION);
+                return 0;
             } else if (argv[i][1] == '-') {
                 double_dash = 1;
             } else {
@@ -125,14 +128,16 @@ int main(int argc, char * argv[]) {
     }
 
     if (mode == 0) {
-        fprintf(stderr, "bzip3 - A better and stronger spiritual successor to bzip2.\n");
+        fprintf(stderr, "bzip3 version %s\n", VERSION);
+        fprintf(stderr, "- A better and stronger spiritual successor to bzip2.\n");
         fprintf(stderr, "Copyright (C) by Kamila Szewczyk, 2022. Licensed under the terms of LGPLv3.\n");
-        fprintf(stderr, "Usage: bzip3 [-e/-d/-t/-c/-h] [-b block_size] input output\n");
+        fprintf(stderr, "Usage: bzip3 [-e/-d/-t/-c/-h/-v] [-b block_size] input output\n");
         fprintf(stderr, "Operations:\n");
         fprintf(stderr, "  -e: encode\n");
         fprintf(stderr, "  -d: decode\n");
         fprintf(stderr, "  -t: test\n");
         fprintf(stderr, "  -h: help\n");
+        fprintf(stderr, "  -v: version\n");
         fprintf(stderr, "Extra flags:\n");
         fprintf(stderr, "  -c: force reading/writing from standard streams\n");
         fprintf(stderr, "  -b N: set block size in MiB\n");

--- a/src/main.c
+++ b/src/main.c
@@ -43,6 +43,7 @@ int is_numeric(const char * str) {
 int main(int argc, char * argv[]) {
     // -1: decode, 0: unspecified, 1: encode, 2: test
     int mode = 0;
+    int args_status = 1;
 
     // input and output file names
     char *input = NULL, *output = NULL;
@@ -97,6 +98,9 @@ int main(int argc, char * argv[]) {
                 workers = atoi(argv[i + 1]);
                 i++;
 #endif
+            } else if (argv[i][1] == 'h') {
+                mode = 0;
+                args_status = 0;
             } else if (argv[i][1] == '-') {
                 double_dash = 1;
             } else {
@@ -123,18 +127,19 @@ int main(int argc, char * argv[]) {
     if (mode == 0) {
         fprintf(stderr, "bzip3 - A better and stronger spiritual successor to bzip2.\n");
         fprintf(stderr, "Copyright (C) by Kamila Szewczyk, 2022. Licensed under the terms of LGPLv3.\n");
-        fprintf(stderr, "Usage: bzip3 [-e/-d/-t/-c] [-b block_size] input output\n");
+        fprintf(stderr, "Usage: bzip3 [-e/-d/-t/-c/-h] [-b block_size] input output\n");
         fprintf(stderr, "Operations:\n");
         fprintf(stderr, "  -e: encode\n");
         fprintf(stderr, "  -d: decode\n");
         fprintf(stderr, "  -t: test\n");
+        fprintf(stderr, "  -h: help\n");
         fprintf(stderr, "Extra flags:\n");
         fprintf(stderr, "  -c: force reading/writing from standard streams\n");
         fprintf(stderr, "  -b N: set block size in MiB\n");
 #ifdef PTHREAD
         fprintf(stderr, "  -j N: set the amount of parallel threads\n");
 #endif
-        return 1;
+        return args_status;
     }
 
     if (mode != 2) {


### PR DESCRIPTION
I added a `-v` flag to the binary that outputs the version as configured at build time. For tagged commits this should be the SEMVER bit only, for HEAD versions in between tags it should show some `git describe` output to pinpoint the current commit (including noting whether the tree was dirty or not at build time). This should help with bug reports from the wild as well as developers shuffiling multiple binaries around for testing.

I also added a `-h` flag to explicitly get the help output without returning an error status.

