### PR TITLE
Fix CI build without pthread

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         platform: [ ubuntu-latest, macos-latest ]
         compiler: [ clang, gcc ]
-        feature: [ enable-pthread, disable-pthread ]
+        feature: [ with-pthread, without-pthread ]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Download source package artifact


### PR DESCRIPTION
This fixes an oversight on my part. Half way through #12 I realized `--(en|dis)able-pthread` was the wrong argument type and it should be `--with(|out)-pthread` instead. It can still be used as an on/off toggle, but if we ever need it this way we can use the with variant to get a path to the specific pthread headers to use rather than only autodetecting them. That last bit isn't setup I don't think, but this is at least the right kind of flag so we don't have to change it later.

I just forgot to fix the CI matrix after I changed it.