### PR TITLE
Fixup rountrip test to play nice on `bmake`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ bzip3
 bzip3-*
 .version
 .version-prev
+LICENSE2
 
 # Autotools
 .deps/

--- a/Makefile.am
+++ b/Makefile.am
@@ -37,7 +37,7 @@ CLEANFILES += $(BUILT_SOURCES) .version-prev
 
 src/bzip3-main.$(OBJEXT): .version
 
-_BRANCH_REF != $(AWK) '{print ".git/" $$2}' .git/HEAD 2>/dev/null
+_BRANCH_REF != $(AWK) '{print ".git/" $$2}' .git/HEAD 2>/dev/null ||:
 
 .version: $(_BRANCH_REF)
 	@if [ -e "$(srcdir)/.tarball-version" ]; then \
@@ -64,7 +64,13 @@ format: $(bzip3_SOURCES) $(include_HEADERS) $(noinst_HEADERS)
 cloc: $(bzip3_SOURCES) $(include_HEADERS) $(noinst_HEADERS)
 	cloc $^
 
+CLEANFILES += LICENSE2
 .PHONY: roundtrip
-roundtrip: $(bin_PROGRAMS)
-	time ./$< -e -b 6 etc/shakespeare.txt
-	time ./$< -d etc/shakespeare.txt.bz3
+
+BZIP3 := bzip3$(EXEEXT)
+
+roundtrip: $(BZIP3)
+	rm -f LICENSE2
+	./$(BZIP3) -e -b 6 LICENSE
+	./$(BZIP3) -d LICENSE.bz3 LICENSE2
+	cmp LICENSE LICENSE2


### PR DESCRIPTION
See #22. Merge then rebase the other CI work onto master to get the BSD fixups and all should be good.