### PR TITLE
set binary mode for standard in/output

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -18,12 +18,17 @@
  */
 
 #include <ctype.h>
+#include <errno.h>
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#if defined __MSVCRT__
+  #include <fcntl.h>
+  #include <io.h>
+#endif
 
 #include "common.h"
 #include "libbz3.h"
@@ -146,6 +151,13 @@ int main(int argc, char * argv[]) {
 #endif
         return args_status;
     }
+    #ifndef O_BINARY
+		#define O_BINARY 0
+    #endif
+    #if defined(__MSVCRT__)
+		setmode(STDIN_FILENO, O_BINARY);
+		setmode(STDOUT_FILENO, O_BINARY);
+    #endif
 
     if (mode != 2) {
         if (no_bz3_suffix || mode == 1) {


### PR DESCRIPTION
In windows your program changes LF into CRLF which makes output archive unusable.
This fixes it.
