### PR TITLE
make compression default action

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -128,7 +128,7 @@ static int is_numeric(const char * str) {
 }
 
 int main(int argc, char * argv[]) {
-    int mode = MODE_UNSPECIFIED;
+    int mode = MODE_ENCODE;
 
     // input and output file names
     char *input = NULL, *output = NULL;


### PR DESCRIPTION
Make compression a default action.

To make it ~~look~~ behave like *nix compressor, make compression default action so it can be used like standard compressor:

./bzip3 \<file\>

It will be, in general, equivalent to
./bzip3 <file> [output-file]

Options work like usual.

It will also allow to be used with tar.
