### PR TITLE
GNU standards for CLI; licence corrected

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -102,7 +102,7 @@ static void version() {
     fprintf(stdout,
             "bzip3 "VERSION"\n"
             "Copyright (C) by Kamila Szewczyk, 2022.\n"
-            "License: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>\n");
+            "License: GNU Lesser GPL version 3 <https://www.gnu.org/licenses/lgpl-3.0.en.html>\n");
     }
 
 static void help() {


### PR DESCRIPTION
I made a mistake in licence in version() function of last [PR](https://github.com/kspalaiologos/bzip3/pull/42) while copying from [page](https://www.gnu.org/prep/standards/html_node/_002d_002dversion.html). It should be LGPLv3, as it is now.
I couldn't go back as that branch was already deleted, therefore new PR. Hope it's the only and last mistake.