### PR TITLE
Package unbzip3 man page

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,7 +20,7 @@ bzip3_CFLAGS = $(AM_CFLAGS)
 bzip3_LDDADD = libbzip3.la
 bzip3_SOURCES = src/main.c $(libbzip3_la_SOURCES)
 
-dist_man_MANS = bzip3.1 bz3cat.1 bz3more.1 bz3less.1 bz3grep.1
+dist_man_MANS = bzip3.1 bz3cat.1 bz3more.1 bz3less.1 bz3grep.1 unbzip3.1
 
 dist_bin_SCRIPTS = bz3cat bz3more bz3less bz3grep unbzip3
 

--- a/bzip3.1
+++ b/bzip3.1
@@ -150,4 +150,4 @@ for performance tests.
 
 
 .SH "SEE ALSO"
-\fBbzip2 (1)\fR, \fBbz3less (1)\fR, \fBbz3more (1)\fR, \fBbz3grep (1)\fR
+\fBbzip2 (1)\fR, \fBbz3less (1)\fR, \fBbz3more (1)\fR, \fBbz3grep (1)\fR, \fBunbzip3\fR


### PR DESCRIPTION
This looks like a small oversight in packaging for the last release. The script got installed and the man pages for all the other scripts got installed but this one got left out.
