### PR TITLE
flockfile/funlockfile for WIN32

### DIFF
--- a/include/getopt-shim.h
+++ b/include/getopt-shim.h
@@ -24,6 +24,11 @@
 #ifndef _GETOPT_H
 #define _GETOPT_H
 
+#ifdef WIN32
+static void flockfile(FILE *f) { _lock_file(f); }
+static void funlockfile(FILE *f) { _unlock_file(f); }
+#endif
+
 int getopt(int, char * const[], const char *);
 extern char * optarg;
 extern int optind, opterr, optopt, optreset;


### PR DESCRIPTION
hi,

the refs to the functions is:
1) https://github.com/kspalaiologos/bzip3/blob/master/include/getopt-shim.h#L52
2) https://github.com/kspalaiologos/bzip3/blob/master/include/getopt-shim.h#L54

according to the MSDN, on WIN32 we can use:
1) https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/lock-file
2) https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/unlock-file

tested on i686 & x86_64 Windows 7 using MinGW-W64 compiler.