### PR TITLE
Version bzip3 library

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,6 @@
 ACLOCAL_AMFLAGS = -I build-aux
 
 AM_CFLAGS = -I$(top_srcdir)/include
-AM_LDFLAGS = -avoid-version
 
 EXTRA_DIST = LICENSE libsais-LICENSE PORTING.md README.md build-aux/git-version-gen
 
@@ -14,6 +13,7 @@ noinst_HEADERS = include/common.h \
 
 lib_LTLIBRARIES = libbzip3.la
 libbzip3_la_SOURCES = src/libbz3.c
+libbzip3_la_LDFLAGS = -version-info 0:0:0
 
 bin_PROGRAMS = bzip3
 bzip3_CFLAGS = $(AM_CFLAGS)


### PR DESCRIPTION
A public-facing library should be versioned because it enables a dynamic linker to recognize when the libary changes ABI and that the consuming application needs to be rebuilt.

This patch employed libtool versioning. See '(libtool)Updating version info' info page for more details how to manage the -version-info numbers.