### PR TITLE
Dynamically link a library to the tool if not disabled

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,8 +17,12 @@ libbzip3_la_SOURCES = src/libbz3.c
 
 bin_PROGRAMS = bzip3
 bzip3_CFLAGS = $(AM_CFLAGS)
-bzip3_LDDADD = libbzip3.la
-bzip3_SOURCES = src/main.c $(libbzip3_la_SOURCES)
+bzip3_SOURCES = src/main.c
+if ENABLE_STATIC
+bzip3_SOURCES += $(libbzip3_la_SOURCES)
+else
+bzip3_LDADD = libbzip3.la
+endif
 
 dist_man_MANS = bzip3.1 bz3cat.1 bz3more.1 bz3less.1 bz3grep.1 bunzip3.1
 

--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,7 @@ AM_CONDITIONAL([ENABLE_ARCH_NATIVE], [test x"$enable_arch_native" != xno])
 
 AC_ARG_ENABLE([static-exe],
 			AS_HELP_STRING([--enable-static-exe], [Enable static builds of the executable.]))
-AM_CONDITIONAL([ENABLE_STATIC], [test x"$enable_static_exe" != x])
+AM_CONDITIONAL([ENABLE_STATIC], [test x"$enable_static_exe" = xyes])
 
 AM_COND_IF([PASSED_CFLAGS], [
 	AC_MSG_NOTICE([skipping compiler feature detection, using '$CFLAGS'])


### PR DESCRIPTION
If a dynamic library is built (--enable-shared --disable-static-exe), the library object files were unnecessarily statically linked to the tool, duplicating the libbz3.c code among the tool and the library:

~~~~
$ ls -l bzip3 .libs/libbzip3.so.0.0.0
-rwxr-xr-x. 1 test test 171096 Oct 26 15:13 bzip3
-rwxr-xr-x. 1 test test 147408 Oct 26 15:13 .libs/libbzip3.so.0.0.0
~~~~

and the tool was not linked to the library at all:

~~~~
$ scanelf -n bzip3
 TYPE   NEEDED FILE
ET_EXEC libc.so.6 bzip3
~~~~

The cause were an unconditional listing of libbz3.c among bzip3 tool sources, a typo in a bzip3_LDADD variable name, wrong evaluation of --disable-static-exe option, and an absence of ENABLE_STATIC aplication in Makefile.am.

This patch fixes all these issues on the assumption that an absence of --{enable,disable}-static-exe option means --disable-static-exe. That assumption is based on a help string of the option. It is a norm that the help string variant displays the nondefault variant:

~~~~
$ ls -l .libs/bzip3 .libs/libbzip3.so.0.0.0
-rwxr-xr-x. 1 test test  35856 Oct 26 15:44 .libs/bzip3
-rwxr-xr-x. 1 test test 147408 Oct 26 15:42 .libs/libbzip3.so.0.0.0

$ scanelf -n .libs/bzip3
 TYPE   NEEDED FILE
ET_EXEC libbzip3.so.0,libc.so.6 .libs/bzip3
~~~~