### PR TITLE
Set rpath in the Makefile

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,6 +22,7 @@ if ENABLE_STATIC
 bzip3_SOURCES += $(libbzip3_la_SOURCES)
 else
 bzip3_LDADD = libbzip3.la
+bzip3_LDFLAGS = -Wl,-rpath -Wl,$(DESTDIR)$(libdir)
 endif
 
 dist_man_MANS = bzip3.1 bz3cat.1 bz3more.1 bz3less.1 bz3grep.1 bunzip3.1

--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,7 @@ if ENABLE_STATIC
 bzip3_SOURCES += $(libbzip3_la_SOURCES)
 else
 bzip3_LDADD = libbzip3.la
-bzip3_LDFLAGS = -Wl,-rpath -Wl,$(DESTDIR)$(libdir)
+bzip3_LDFLAGS = -Wl,-rpath -Wl,$(libdir)
 endif
 
 dist_man_MANS = bzip3.1 bz3cat.1 bz3more.1 bz3less.1 bz3grep.1 bunzip3.1


### PR DESCRIPTION
Debian Linux and Red Hat-derived distributions usually don't add `/usr/local/lib` to the library search path, and since #65 made the `bzip3` binary dependent on `libbz3.so`, on some stock configurations bzip3 might not work out of the box. This patch sets the `rpath` value to the libraries directory allowing us to sidestep this without forcing the user to set `LD_LIBRARY_PATH` manually.