### PR TITLE
fix compiler warnings, %ld to %llu

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -372,11 +372,11 @@ static int process(FILE * input_des, FILE * output_des, int mode, int block_size
     if(verbose) {
         if(file_name) fprintf(stderr, " %s:", file_name);
         if(mode == MODE_ENCODE)
-            fprintf(stderr, "\t%ld -> %ld bytes, %.2f%%, %.2f bpb\n", bytes_read, bytes_written, (double)bytes_written * 100.0 / bytes_read, (double)bytes_written * 8.0 / bytes_read);
+            fprintf(stderr, "\t%llu -> %llu bytes, %.2f%%, %.2f bpb\n", bytes_read, bytes_written, (double)bytes_written * 100.0 / bytes_read, (double)bytes_written * 8.0 / bytes_read);
         else if(mode == MODE_DECODE)
-            fprintf(stderr, "\t%ld -> %ld bytes, %.2f%%, %.2f bpb\n", bytes_read, bytes_written, (double)bytes_read * 100.0 / bytes_written, (double)bytes_read * 8.0 / bytes_written);
+            fprintf(stderr, "\t%llu -> %llu bytes, %.2f%%, %.2f bpb\n", bytes_read, bytes_written, (double)bytes_read * 100.0 / bytes_written, (double)bytes_read * 8.0 / bytes_written);
         else
-            fprintf(stderr, "OK, %ld bytes read.\n", bytes_read);
+            fprintf(stderr, "OK, %llu bytes read.\n", bytes_read);
     }
 
     return 0;


### PR DESCRIPTION
Looks like some warnings got introduced in f25cc45a638e5bedcc58ebaeea59b0a1e526c98c

Before this patch:
```
make -j8
/Applications/Xcode.app/Contents/Developer/usr/bin/make  all-am
  CC       src/libbz3.lo
  CC       src/bzip3-main.o
src/main.c:375:71: warning: format specifies type 'long' but the argument has type 'uint64_t' (aka 'unsigned long long') [-Wformat]
            fprintf(stderr, "\t%ld -> %ld bytes, %.2f%%, %.2f bpb\n", bytes_read, bytes_written, (double)bytes_written * 100.0 / bytes_read, (double)bytes_written * 8.0 / bytes_read);
                               ~~~                                    ^~~~~~~~~~
                               %llu
src/main.c:375:83: warning: format specifies type 'long' but the argument has type 'uint64_t' (aka 'unsigned long long') [-Wformat]
            fprintf(stderr, "\t%ld -> %ld bytes, %.2f%%, %.2f bpb\n", bytes_read, bytes_written, (double)bytes_written * 100.0 / bytes_read, (double)bytes_written * 8.0 / bytes_read);
                                      ~~~                                         ^~~~~~~~~~~~~
                                      %llu
src/main.c:377:71: warning: format specifies type 'long' but the argument has type 'uint64_t' (aka 'unsigned long long') [-Wformat]
            fprintf(stderr, "\t%ld -> %ld bytes, %.2f%%, %.2f bpb\n", bytes_read, bytes_written, (double)bytes_read * 100.0 / bytes_written, (double)bytes_read * 8.0 / bytes_written);
                               ~~~                                    ^~~~~~~~~~
                               %llu
src/main.c:377:83: warning: format specifies type 'long' but the argument has type 'uint64_t' (aka 'unsigned long long') [-Wformat]
            fprintf(stderr, "\t%ld -> %ld bytes, %.2f%%, %.2f bpb\n", bytes_read, bytes_written, (double)bytes_read * 100.0 / bytes_written, (double)bytes_read * 8.0 / bytes_written);
                                      ~~~                                         ^~~~~~~~~~~~~
                                      %llu
src/main.c:379:54: warning: format specifies type 'long' but the argument has type 'uint64_t' (aka 'unsigned long long') [-Wformat]
            fprintf(stderr, "OK, %ld bytes read.\n", bytes_read);
                                 ~~~                 ^~~~~~~~~~
                                 %llu
```

After:

```
make -j8
/Applications/Xcode.app/Contents/Developer/usr/bin/make  all-am
  CC       src/bzip3-main.o
  CCLD     bzip3
```
