### PR TITLE
use mode defined in header

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -533,9 +533,6 @@ int main(int argc, char * argv[]) {
         }
     }
 
-#ifndef O_BINARY
-    #define O_BINARY 0
-#endif
 #if defined(__MSVCRT__)
     setmode(STDIN_FILENO, O_BINARY);
     setmode(STDOUT_FILENO, O_BINARY);


### PR DESCRIPTION
Trying to copy \`setmode()' I realised that checking if `O_BINARY` is defined is redundant, not to mention it meant to be \`0x8000', although it works fine. It's defined since VC-6 and Mingw-3.4, so it can be used as \`O_BINARY'.
Sorry for the mess.
