### PR TITLE
Use `/usr/bin/env sh` for shebangs

### DIFF
--- a/bz3cat
+++ b/bz3cat
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 exec bzip3 -Bcd "$@"

--- a/bz3grep
+++ b/bz3grep
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 #
 # Copyright (c) 2003 Thomas Klausner.
 #

--- a/bz3less
+++ b/bz3less
@@ -1,2 +1,2 @@
-#!/bin/sh
+#!/usr/bin/env sh
 bz3cat "$@" | less

--- a/bz3more
+++ b/bz3more
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 for FILE
 do

--- a/bz3most
+++ b/bz3most
@@ -1,2 +1,2 @@
-#!/bin/sh
+#!/usr/bin/env sh
 bz3cat "$@" | most


### PR DESCRIPTION
The current shebangs on shell scripts use `#!/bin/sh` which is fine. `#!/usr/bin/env sh` uses the PATH environment variable to find an available `sh` shell, and uses the first one it finds. This can be nice for situations where the user has installed a version of `sh` that they prefer in `/usr/local` or something.