### PR TITLE
Build on cygwin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,7 @@ noinst_HEADERS = include/common.h \
 
 lib_LTLIBRARIES = libbzip3.la
 libbzip3_la_SOURCES = src/libbz3.c
-libbzip3_la_LDFLAGS = -version-info 0:0:0
+libbzip3_la_LDFLAGS = -no-undefined -version-info 0:0:0
 
 bin_PROGRAMS = bzip3
 bzip3_CFLAGS = $(AM_CFLAGS)


### PR DESCRIPTION
Build on cygwin

```
$ uname -mrs
CYGWIN_NT-10.0-19045 3.4.3-1.x86_64 x86_64
$ cd bzip3
$ ./bootstrap.sh
$ ./configure --enable-shared --disable-static CC=gcc
$ make V=1
make  all-am
make[1]: Entering directory '/cygdrive/e/bzip3'
/bin/sh ./libtool  --tag=CC   --mode=link gcc -I./include -g -O2 -pthread -DPTHREAD -O2 -g3 -fPIC -march=native -mtune=native -version-info 0:0:0  -o libbzip3.la -rpath /usr/local/lib src/libbz3.lo  -lpthread
libtool:   error: can't build x86_64-pc-cygwin shared library unless -no-undefined is specified
make[1]: *** [Makefile:575: libbzip3.la] Error 1
make[1]: Leaving directory '/cygdrive/e/bzip3'
make: *** [Makefile:433: all] Error 2
```