### PR TITLE
README.md: adding note about homebrew on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Alternatively, you might be able to install bzip3 using your system's package ma
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/bzip3.svg)](https://repology.org/project/bzip3/versions)
 
+On macOS, you can use [Homebrew](https://brew.sh) to easily install:
+
+```console
+$ brew install bzip3
+```
+
 ## Perl source code benchmark
 
 First, I have downloaded every version of Perl5 ever released and decompressed them.


### PR DESCRIPTION
The formula for ``bzip3`` was added to the homebrew repository:

https://github.com/Homebrew/homebrew-core/blob/master/Formula/bzip3.rb

This means you can easily install it on all the recent macOS versions using ``brew install bzip3``.

