### PR TITLE
Fix: free output after being used

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -690,6 +690,7 @@ int main(int argc, char * argv[]) {
 
     output_des = mode != MODE_TEST ? open_output(output, force) : NULL;
     input_des = open_input(input);
+    free(output);
 
     int r = process(input_des, output_des, mode, block_size, workers, verbose, input);
 


### PR DESCRIPTION
https://github.com/kspalaiologos/bzip3/blob/5dc0802d64b5b5702997eff6b228623fedfb0204/src/main.c#L656
https://github.com/kspalaiologos/bzip3/blob/5dc0802d64b5b5702997eff6b228623fedfb0204/src/main.c#L672
`malloc` here allocates some space on the heap but doesn't free it after being used. 

Compiling with GCC (address sanitization enabled) detected this issue.
```
Direct leak of 12 byte(s) in 1 object(s) allocated from:
    #0 0x7f03ae4beedf in __interceptor_malloc (/usr/lib/libasan.so.8+0xbeedf)
    #1 0x55da54e41ed7 in main src/main.c:656

SUMMARY: AddressSanitizer: 12 byte(s) leaked in 1 allocation(s).
```