### PR TITLE
Revert PR #89

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -690,7 +690,6 @@ int main(int argc, char * argv[]) {
 
     output_des = mode != MODE_TEST ? open_output(output, force) : NULL;
     input_des = open_input(input);
-    free(output);
 
     int r = process(input_des, output_des, mode, block_size, workers, verbose, input);
 


### PR DESCRIPTION
Closes #90

This is a naive approach to getting a working build again from the *master* branch. I don't understand completely what #89 was supposed to fix, but whatever it was supposed to do it broke everything else. This simply reverts the change. A better fix may be possible, either to configure in a way that the code works or to solve the same original problem in a better way, but pending such a thing being proposed I suggest the default HEAD version working and passing tests.
