### PR TITLE
Add `--rm` option

### DIFF
--- a/bzip3.1.in
+++ b/bzip3.1.in
@@ -101,6 +101,10 @@ Display a help message and exit.
 .B \-j --jobs N
 Set the amount of parallel worker threads that process one block each.
 .TP
+.B \--rm
+Remove the input files after successful compression or decompression. This is
+silently ignored if output is stdout.
+.TP
 .B \-k --keep
 Keep (don't delete) the input files. Set by default, provided only
 for compatibility with other compressors.

--- a/src/libbz3.c
+++ b/src/libbz3.c
@@ -271,8 +271,7 @@ static int mrled(u8 * RESTRICT in, u8 * RESTRICT out, s32 outlen, s32 maxin) {
     s32 t[256] = { 0 };
     s32 run = 0;
 
-    if(maxin < 32)
-        return 1;
+    if (maxin < 32) return 1;
 
     for (s32 i = 0; i < 32; ++i) {
         c = in[ip++];
@@ -709,7 +708,7 @@ BZIP3_API s32 bz3_decode_block(struct bz3_state * state, u8 * buffer, s32 data_s
 
     if (model & 4) {
         int err = mrled(b1, b2, orig_size, size_src);
-        if(err) {
+        if (err) {
             state->last_error = BZ3_ERR_CRC;
             return -1;
         }

--- a/src/main.c
+++ b/src/main.c
@@ -59,7 +59,7 @@ static void help() {
             "Operations:\n"
             "  -e/-z, --encode   compress data (default)\n"
             "  -d, --decode      decompress data\n"
-			"  -r, --recover     attempt at recovering corrupted data\n"
+            "  -r, --recover     attempt at recovering corrupted data\n"
             "  -t, --test        verify validity of compressed data\n"
             "  -h, --help        display an usage overview\n"
             "  -f, --force       force overwriting output if it already exists\n"
@@ -78,8 +78,7 @@ static void help() {
 }
 
 static void xwrite(const void * data, size_t size, size_t len, FILE * des) {
-    if (len == 0 || size == 0)
-        return;
+    if (len == 0 || size == 0) return;
     if (fwrite(data, size, len, des) != len) {
         fprintf(stderr, "Write error: %s\n", strerror(errno));
         exit(1);
@@ -169,7 +168,7 @@ static int process(FILE * input_des, FILE * output_des, int mode, int block_size
 
             bytes_written += 9;
             break;
-		case MODE_RECOVER:
+        case MODE_RECOVER:
         case MODE_DECODE:
         case MODE_TEST: {
             char signature[5];
@@ -187,12 +186,12 @@ static int process(FILE * input_des, FILE * output_des, int mode, int block_size
                 fprintf(stderr,
                         "The input file is corrupted. Reason: Invalid block "
                         "size in the header.\n");
-				if(mode == MODE_RECOVER) {
-					fprintf(stderr, "Recovery mode: Proceeding.\n");
-					block_size = MiB(511);
-				} else {
-					return 1;
-				}
+                if (mode == MODE_RECOVER) {
+                    fprintf(stderr, "Recovery mode: Proceeding.\n");
+                    block_size = MiB(511);
+                } else {
+                    return 1;
+                }
             }
 
             bytes_read += 9;
@@ -554,7 +553,7 @@ int main(int argc, char * argv[]) {
                                             { "test", no_argument, 0, 't' },
                                             { "stdout", no_argument, 0, 'c' },
                                             { "force", no_argument, 0, 'f' },
-											{ "recover", no_argument, 0, 'r' },
+                                            { "recover", no_argument, 0, 'r' },
                                             { "help", no_argument, 0, 'h' },
                                             { "keep", no_argument, 0, 'k' },
                                             { "version", no_argument, 0, 'V' },
@@ -582,7 +581,7 @@ int main(int argc, char * argv[]) {
             case 'd':
                 mode = MODE_DECODE;
                 break;
-			case 'r':
+            case 'r':
                 mode = MODE_RECOVER;
                 break;
             case 't':
@@ -662,7 +661,7 @@ int main(int argc, char * argv[]) {
                     if (!force_stdstreams) free(output_name);
                 }
                 break;
-			case MODE_RECOVER:
+            case MODE_RECOVER:
             case MODE_DECODE:
                 /* Decode each of the files. */
                 while (optind < argc) {


### PR DESCRIPTION
This is an option to remove input files after successful compression or decompression. This is silently ignored if output is stdout.

Also, I am running `clang-format` with this change and before it.

Closes #122