### PR TITLE
Fixed: Removed no longer present field in high_level_format.md

### DIFF
--- a/doc/high_level_format.md
+++ b/doc/high_level_format.md
@@ -1,4 +1,4 @@
 
 # High level API bzip3 frame format.
 
-The bzip3 frame format is a concatenation of bzip3-compressed blocks. It's used exclusively by the `bz3_compress` and `bz3_decompress` functions and will not work with the command-line tool or low level functions. Each frame start with the ASCII "BZ3v1" signature, followed by the 32-bit maximum block size in bytes and the 32-bit amount of blocks in the frame. After the 13 byte header, a sequence of independent blocks encoded using the low level API follows.
+The bzip3 frame format is a concatenation of bzip3-compressed blocks. It's used exclusively by the `bz3_compress` and `bz3_decompress` functions and will not work with the command-line tool or low level functions. Each frame start with the ASCII "BZ3v1" signature, followed by the 32-bit maximum block size in bytes. After the 9 byte header, a sequence of independent blocks encoded using the low level API follows.


### PR DESCRIPTION
This fixes an inaccuracy in `high_level_format.md`.

The file lists a field which no longer exists; so it has been removed from the documentation.
That's about it.

![image](https://github.com/user-attachments/assets/67ed485e-a5ca-4685-a2dc-00b5a9029157)

Above is a visualization in ImHex. My first time using that hex editor, thought it would be a fun exercise.