### PR TITLE
Improved: Make fuzzing setup guide a tiny bit clearer.

### DIFF
--- a/examples/fuzz.c
+++ b/examples/fuzz.c
@@ -1,15 +1,44 @@
 
 /* A tiny utility for fuzzing bzip3.
  *
- * Instructions:
+ * Prerequisites:
+ * 
+ * - AFL https://github.com/AFLplusplus/AFLplusplus
+ * - clang (part of LLVM)
+ * 
+ * On Arch this is `pacman -S afl++ clang`
+ *
+ * # Instructions:
+ * 
+ * 1. Build the Repository (per example in README.md)
+ * 
+ * This will get you a working binary of `bzip3` (in repo root).
+ * Then cd into this (examples) folder.
+ * 
+ * 2. Prepare fuzzer directories
+ * 
  * mkdir -p afl_in && mkdir -p afl_out
- * ./compress-file ../Makefile afl_in/a.bz3
- * afl-clang examples/fuzz.c -Iinclude src/libbz3.c -o examples/fuzz -g3 "-DVERSION=\"0.0.0\"" -O3 -march=native
+ * 
+ * 3. Make a fuzzer input file.
+ * 
+ * With `your_file` being an arbitrary input to test.
+ * 
+ * ../bzip3 -e your_file
+ * mv your_file.bz3 afl_in/
+ * 
+ * 4. Build instrumented binary.
+ * 
+ * afl-clang fuzz.c -I../include ../src/libbz3.c -o fuzz -g3 "-DVERSION=\"0.0.0\"" -O3 -march=native
+ * 
+ * 5. Run the fuzzer.
+ * 
  * AFL_SKIP_CPUFREQ=1 afl-fuzz -i afl_in -o afl_out -- ./fuzz @@
  *
+ * 6. Found a crash?
+ * 
  * If you find a crash, consider also doing the following:
- * gcc examples/fuzz.c src/libbz3.c -g3 -O3 -march=native -o examples/fuzz_asan -Iinclude "-DVERSION=\"0.0.0\""
- * -fsanitize=undefined -fsanitize=address
+ * 
+ * clang fuzz.c ../src/libbz3.c -g3 -O3 -march=native -o fuzz_asan -I../include "-DVERSION=\"0.0.0\"" -fsanitize=undefined -fsanitize=address
  *
  * And run fuzz_asan on the crashing test case. Attach the test case /and/ the output of fuzz_asan to the bug report.
  */
@@ -30,6 +59,7 @@ int main(int argc, char ** argv) {
 
     if (size < 64) {
         // Too small.
+        free(buffer);
         return 0;
     }
 
@@ -37,17 +67,19 @@ int main(int argc, char ** argv) {
     size_t orig_size = *(size_t *)buffer;
     if (orig_size >= 0x10000000) {
         // Sanity check: don't allocate more than 256MB.
+        free(buffer);
         return 0;
     }
     uint8_t * outbuf = malloc(orig_size);
     int bzerr = bz3_decompress(buffer + sizeof(size_t), outbuf, size - sizeof(size_t), &orig_size);
     if (bzerr != BZ3_OK) {
         printf("bz3_decompress() failed with error code %d", bzerr);
+        free(outbuf);
+        free(buffer);
         return 1;
     }
 
     printf("OK, %d => %d", size, orig_size);
-
     free(outbuf);
     free(buffer);
     return 0;


### PR DESCRIPTION
This is a small patch around the fuzzer example.
Makes it more friendly for non-C devs.

Changes are pretty small:

- Explicitly specifies current directory (previously it required you to change it, for `afl-clang`, without indication).
- The command to build with UndefinedBehaviour/AddressSanitizer was changed to `clang` from `gcc`, to match `afl-clang` usage above. [unless the difference was deliberate, then please undo in commit]
- Replaced removed `compress-test` mention with an instruction to run binary.

Since the `compress-test` example no longer exists (it was removed, as it served as a bad example of how to use C, according to commit message); I updated the docs to instead direct the user to build the main binary to use for compressing the input.

I also added some free(s) to the fuzz binary, so an unsuspecting user doesn't get scared by `LeakSanitizer` unnecessarily.
Obviously some C API errors are unhandled in `fuzz.c`, but it shouldn't complain on the happy paths.