### PR TITLE
Add License variable to pkg-config file

### DIFF
--- a/bzip3.pc.in
+++ b/bzip3.pc.in
@@ -7,5 +7,6 @@ includedir=@includedir@
 Name: @PACKAGE@
 Description: A better and stronger spiritual successor to BZip2
 Version: @PACKAGE_VERSION@
+License: LGPL-3.0-or-later
 Libs: -L${libdir} -lbzip3
 Cflags: -I${includedir}


### PR DESCRIPTION
The pkg-config file has License variable that allows you to set the license for the software. 
This sets LGPL-3.0-or-later to License.

Ref: https://github.com/pkgconf/pkgconf/blob/master/man/pc.5#L116