### PR TITLE
autoconf: Define extra_cflags variable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,7 @@ AM_CONDITIONAL([ENABLE_ARCH_NATIVE], [test x"$enable_arch_native" != xno])
 AC_ARG_ENABLE([static-exe],
 			AS_HELP_STRING([--enable-static-exe], [Enable static builds of the executable.]))
 AM_CONDITIONAL([ENABLE_STATIC], [test x"$enable_static_exe" = xyes])
+AC_SUBST([extra_cflags], [])
 
 AM_COND_IF([PASSED_CFLAGS], [
 	AC_MSG_NOTICE([skipping compiler feature detection, using '$CFLAGS'])


### PR DESCRIPTION
Building with autotools on Linux produces bzip3.pc with a garbage in Cflags:

    [...]
    Libs: -L${libdir} -lbzip3
    Cflags: -I${includedir}@extra_cflags@

This bug was introduced in dca13c82311e60cc47f01623d6281119024b5b44 commit (Fix handling of DLLs on Windows) which added @extra_cflags@ to pkg-config file and defined the variable in CMake script, but forgot to define it in an Autoconf script.

This patch defines it unconditionally in the Autoconf script as an empty string, assuming people don't use this script on Windows platforms.