### PR TITLE
Document default value of --jobs and --block

### DIFF
--- a/bzip3.1.in
+++ b/bzip3.1.in
@@ -80,7 +80,7 @@ files in the current directory.
 .TP
 .B \-b --block N
 Set the block size to N mebibytes. The minimum is 1MiB, the maximum is
-511MiB.
+511MiB. The default is 16MiB.
 .TP
 .B \-c --stdout
 Force writing output data to the standard output if one file is
@@ -99,7 +99,8 @@ Overwrite existing files.
 Display a help message and exit.
 .TP
 .B \-j --jobs N
-Set the amount of parallel worker threads that process one block each.
+Set the amount of parallel worker threads that process one block each. Default
+is to use 1 worker thread.
 .TP
 .B \--rm
 Remove the input files after successful compression or decompression. This is

--- a/src/main.c
+++ b/src/main.c
@@ -68,7 +68,7 @@ static void help() {
             "  -b N, --block=N   set block size in MiB {16}\n"
             "  -B, --batch       process all files specified as inputs\n"
 #ifdef PTHREAD
-            "  -j N, --jobs=N    set the amount of parallel threads\n"
+            "  -j N, --jobs=N    set the amount of parallel threads {1}\n"
 #endif
             "\n"
             "Report bugs to: https://github.com/iczelia/bzip3\n");


### PR DESCRIPTION
Somewhat unobvious what the default is: you need to read the source or compress a sufficiently large file and check with top.

For --block it was mentioned in the --help output but not the manpage.